### PR TITLE
Add support to detect setup.cfg

### DIFF
--- a/pynixify/data/setuptools_patch.diff
+++ b/pynixify/data/setuptools_patch.diff
@@ -1,16 +1,13 @@
 diff --git a/setuptools/__init__.py b/setuptools/__init__.py
-index a71b2bbd..400952d9 100644
+index a71b2bbd..3dbb72bb 100644
 --- a/setuptools/__init__.py
 +++ b/setuptools/__init__.py
-@@ -139,10 +139,42 @@ def _install_setup_requires(attrs):
-         dist.fetch_build_eggs(dist.setup_requires)
- 
- 
--def setup(**attrs):
--    # Make sure we have any requirements needed to interpret 'attrs'.
--    _install_setup_requires(attrs)
--    return distutils.core.setup(**attrs)
-+def setup( **attrs):
+@@ -135,14 +135,48 @@ def _install_setup_requires(attrs):
+     ))
+     # Honor setup.cfg's options.
+     dist.parse_config_files(ignore_option_errors=True)
+-    if dist.setup_requires:
+-        dist.fetch_build_eggs(dist.setup_requires)
 +    if 'PYPI2NIXKPGS' in os.environ:
 +        from pathlib import Path
 +        try:
@@ -18,9 +15,11 @@ index a71b2bbd..400952d9 100644
 +        except KeyError:
 +            print("out environment variable not defined")
 +            sys.exit(1)
++        setup_requires = dist.setup_requires
++        install_requires = dist.install_requires
 +        targets = [
-+            ('setup_requires.txt', attrs.get('setup_requires', [])),
-+            ('install_requires.txt', attrs.get('install_requires', [])),
++            ('setup_requires.txt', attrs.get('setup_requires', setup_requires)),
++            ('install_requires.txt', attrs.get('install_requires', install_requires)),
 +            ('tests_requires.txt', attrs.get('tests_require', [])),
 +        ]
 +        for (filename, requirements) in targets:
@@ -33,7 +32,7 @@ index a71b2bbd..400952d9 100644
 +                    fp.write(requirements)
 +                else:
 +                    fp.write('\n'.join(requirements))
-+
+ 
 +        import json
 +        meta = {}
 +        meta_attrs = {'description', 'url', 'license'}
@@ -41,10 +40,17 @@ index a71b2bbd..400952d9 100644
 +            meta[meta_attr] = attrs.get(meta_attr)
 +        with (out / 'meta.json').open('w') as fp:
 +            json.dump(meta, fp)
-+
 +    else:
-+        # Make sure we have any requirements needed to interpret 'attrs'.
-+        _install_setup_requires(attrs)
++        if dist.setup_requires:
++            dist.fetch_build_eggs(dist.setup_requires)
+ 
+-def setup(**attrs):
++
++def setup( **attrs):
+     # Make sure we have any requirements needed to interpret 'attrs'.
+     _install_setup_requires(attrs)
+-    return distutils.core.setup(**attrs)
++    if 'PYPI2NIXKPGS' not in os.environ:
 +        return distutils.core.setup(**attrs)
  
  setup.__doc__ = distutils.core.setup.__doc__


### PR DESCRIPTION
Some python packages uses empty setup() and all dependencies are
saved on setup.cfg file.

This commit updates the setuptools v44.0.0 patch for saving deps on
.txt files