### PR TITLE
Fix for darwin

### DIFF
--- a/pynixify/data/pythonPackages.nix
+++ b/pynixify/data/pythonPackages.nix
@@ -16,10 +16,14 @@ let
     let 
       d = {attr=name; version=value.version;};
     in
-      if !value ? src then [ (d // {src=null;})]
-      else if !(builtins.tryEval value.src ).success then [ ]
-      else if !value.src ? urls then [(d // {src=null;})]
-      else [ (d // {src=builtins.head value.src.urls;})];
+    if !value ? src then 
+      [ (d // {src=null;})]
+    else if !(builtins.tryEval value.src ).success then 
+      [ ]
+    else if !value.src ? urls then 
+      [(d // {src=null;})]
+    else 
+      [ (d // {src=builtins.head value.src.urls;})];
 
   sources = packages:
     lib.concatMap ({ key, value }:


### PR DESCRIPTION
Constructing the list of nixpkgs python packages failed on mac because
the .src attribute `pytorch-bin` package throws an error. This error was
not caught  by the tryEval logic in pynixify because of nix's lazy
evaluation.

This PR fixes this problem and enables pynixify on darwin.

Resolves #53